### PR TITLE
custom-read-timeout-and-connection-timeout

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/biz/client/AdminBizClient.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/biz/client/AdminBizClient.java
@@ -17,9 +17,11 @@ public class AdminBizClient implements AdminBiz {
 
     public AdminBizClient() {
     }
-    public AdminBizClient(String addressUrl, String accessToken) {
+    public AdminBizClient(String addressUrl, String accessToken, int readTimeout, int connectTimeout) {
         this.addressUrl = addressUrl;
         this.accessToken = accessToken;
+        this.readTimeout = readTimeout;
+        this.connectTimeout = connectTimeout;
 
         // valid
         if (!this.addressUrl.endsWith("/")) {
@@ -29,20 +31,22 @@ public class AdminBizClient implements AdminBiz {
 
     private String addressUrl ;
     private String accessToken;
+    private int readTimeout = 3;
+    private int connectTimeout = 3;
 
 
     @Override
     public ReturnT<String> callback(List<HandleCallbackParam> callbackParamList) {
-        return XxlJobRemotingUtil.postBody(addressUrl+"api/callback", accessToken, callbackParamList, 3);
+        return XxlJobRemotingUtil.postBody(addressUrl+"api/callback", accessToken, callbackParamList, readTimeout, connectTimeout);
     }
 
     @Override
     public ReturnT<String> registry(RegistryParam registryParam) {
-        return XxlJobRemotingUtil.postBody(addressUrl + "api/registry", accessToken, registryParam, 3);
+        return XxlJobRemotingUtil.postBody(addressUrl + "api/registry", accessToken, registryParam, readTimeout, connectTimeout);
     }
 
     @Override
     public ReturnT<String> registryRemove(RegistryParam registryParam) {
-        return XxlJobRemotingUtil.postBody(addressUrl + "api/registryRemove", accessToken, registryParam, 3);
+        return XxlJobRemotingUtil.postBody(addressUrl + "api/registryRemove", accessToken, registryParam, readTimeout, connectTimeout);
     }
 }

--- a/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/executor/XxlJobExecutor.java
@@ -38,6 +38,8 @@ public class XxlJobExecutor  {
     private String accessToken;
     private String logPath;
     private int logRetentionDays;
+    private int readTimeout;
+    private int connectionTimeout;
 
     public void setAdminAddresses(String adminAddresses) {
         this.adminAddresses = adminAddresses;
@@ -60,6 +62,12 @@ public class XxlJobExecutor  {
     public void setLogRetentionDays(int logRetentionDays) {
         this.logRetentionDays = logRetentionDays;
     }
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
 
 
     // ---------------------- start + stop ----------------------
@@ -69,7 +77,7 @@ public class XxlJobExecutor  {
         XxlJobFileAppender.initLogPath(logPath);
 
         // init invoker, admin-client
-        initAdminBizList(adminAddresses, accessToken);
+        initAdminBizList(adminAddresses, accessToken, readTimeout, connectionTimeout);
 
 
         // init JobLogFileCleanThread
@@ -109,12 +117,12 @@ public class XxlJobExecutor  {
     // ---------------------- admin-client (rpc invoker) ----------------------
     private static List<AdminBiz> adminBizList;
     private static Serializer serializer = new HessianSerializer();
-    private void initAdminBizList(String adminAddresses, String accessToken) throws Exception {
+    private void initAdminBizList(String adminAddresses, String accessToken, int readTimeout, int connectTimeout) throws Exception {
         if (adminAddresses!=null && adminAddresses.trim().length()>0) {
             for (String address: adminAddresses.trim().split(",")) {
                 if (address!=null && address.trim().length()>0) {
 
-                    AdminBiz adminBiz = new AdminBizClient(address.trim(), accessToken);
+                    AdminBiz adminBiz = new AdminBizClient(address.trim(), accessToken, readTimeout, connectTimeout);
 
                     if (adminBizList == null) {
                         adminBizList = new ArrayList<AdminBiz>();

--- a/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/util/XxlJobRemotingUtil.java
@@ -60,7 +60,7 @@ public class XxlJobRemotingUtil {
      * @param requestObj
      * @return
      */
-    public static ReturnT<String> postBody(String url, String accessToken, Object requestObj, int timeout) {
+    public static ReturnT<String> postBody(String url, String accessToken, Object requestObj, int readTimeout, int connectTimeout) {
         HttpURLConnection connection = null;
         BufferedReader bufferedReader = null;
         try {
@@ -80,8 +80,8 @@ public class XxlJobRemotingUtil {
             connection.setDoOutput(true);
             connection.setDoInput(true);
             connection.setUseCaches(false);
-            connection.setReadTimeout(timeout * 1000);
-            connection.setConnectTimeout(3 * 1000);
+            connection.setReadTimeout(readTimeout * 1000);
+            connection.setConnectTimeout(connectTimeout * 1000);
             connection.setRequestProperty("connection", "Keep-Alive");
             connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
             connection.setRequestProperty("Accept-Charset", "application/json;charset=UTF-8");


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [√] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


**The description of the PR:**
针对问题 #1379 和建议 #1386 ，发起此次pull request。
主要是可以将超时时间 readTimeout 和 connectionTimeout 进行自定义配置，不配置时默认值仍为源码中的数字3。

新增代码三处：
1、com.xxl.job.core.biz.client.AdminBizClient 新增 readTimeout 和 connectionTimeout。
2、com.xxl.job.core.executor.XxlJobExecutor 新增 readTimeout 和 connectionTimeout。
3、com.xxl.job.core.util.XxlJobRemotingUtil 新增 readTimeout 和 connectionTimeout。


**Other information:**
本地编译打包，测试通过验证后，提交本pull request。